### PR TITLE
'w0rp/ale' => 'dense-analysis/ale'

### DIFF
--- a/vim/plugins.vim
+++ b/vim/plugins.vim
@@ -18,7 +18,7 @@ Plug 'rhysd/committia.vim'
 Plug 'tpope/vim-git'
 
 " ale plugin
-Plug 'w0rp/ale'
+Plug 'dense-analysis/ale'
 
 " deoplete
 if has('nvim')


### PR DESCRIPTION
'w0rp/ale' was transferred to 'dense-analysis/ale'.
It begs a change