### PR TITLE
Fix order of nvim execution upgrades

### DIFF
--- a/bin/upgrade
+++ b/bin/upgrade
@@ -101,7 +101,7 @@ node_python_pkgs_update() (
 
 neovim_plugings_upgrade() {
     if command -v nvim >/dev/null 2>&1; then
-        for cmd in "PlugUpgrade" "PlugInstall" "PlugClean!" "PlugUpdate" "UpdateRemotePlugins"; do
+        for cmd in "PlugClean!" "PlugUpdate!" "PlugInstall" "UpdateRemotePlugins" "PlugUpgrade"; do
             nvim \
                 --headless \
                 -es \


### PR DESCRIPTION
`PlugClean` has to be done first to remove all invalid plugins first. It became visible after #372 was merged and `vim-plug` was unable to update `ale` due to conflict in name.