### PR TITLE
Add `jq` to my packages

### DIFF
--- a/.installer/verify_install.sh
+++ b/.installer/verify_install.sh
@@ -52,6 +52,8 @@ validate_bin_accessible() (
     tree
     aria2c
     ctags
+    htop
+    jq
   );
   for bin in "${bins_to_check[@]}"; do
     if command -v "${bin}" >/dev/null 2>&1; then

--- a/pkg.install.conf.yaml
+++ b/pkg.install.conf.yaml
@@ -117,6 +117,7 @@
       indicator-cpufreq,
       snapd,
       htop,
+      jq,
     ]
 
 # cleanup


### PR DESCRIPTION
Closes #401

Snap installed software is weird. It cannot be verified if it was installed, at least that part seems to be tricky when done in CI environment.
Let's have important software done in traditional way.