### PR TITLE
Add fzf finder via zinit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,11 +3,6 @@
     url = https://github.com/anishathalye/dotbot
     shallow = true
     branch = master
-[submodule "fzf"]
-    path = dependencies/fzf
-    url = https://github.com/junegunn/fzf.git
-    shallow = true
-    branch = master
 [submodule "dependencies/pyenv"]
     path = dependencies/pyenv
     url = https://github.com/pyenv/pyenv.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,6 +3,11 @@
     url = https://github.com/anishathalye/dotbot
     shallow = true
     branch = master
+[submodule "fzf"]
+    path = dependencies/fzf
+    url = https://github.com/junegunn/fzf.git
+    shallow = true
+    branch = master
 [submodule "dependencies/pyenv"]
     path = dependencies/pyenv
     url = https://github.com/pyenv/pyenv.git

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -79,7 +79,6 @@
     ~/.zinit: dependencies/zinit
 
     # fzf
-    ~/.fzf: dependencies/fzf
     ~/.fzf.settings: fzf.settings
 
     # go

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -153,6 +153,23 @@ zinit ice \
     atload'zstyle ":completion:*" list-colors “${(s.:.)LS_COLORS}”'
 zinit light trapd00r/LS_COLORS
 
+# fzf: binary
+zinit ice \
+    lucid \
+    wait'0b' \
+    from"gh-r" \
+    as"program" \
+    atload"source ~/.fzf.settings"
+zinit light junegunn/fzf
+# fzf: completions and key bindings
+zinit ice \
+    lucid \
+    wait'0c' \
+    multisrc"shell/{completion,key-bindings}.zsh" \
+    id-as"junegunn/fzf_completions" \
+    pick"/dev/null"
+zinit light junegunn/fzf
+
 # replacement for ls
 zinit ice \
     wait'2' \


### PR DESCRIPTION
This change will make it possible to use fzf without a need to go through `apt` or `yay` package managers making
my setup more portable.